### PR TITLE
Chave primaria com Sequence e TableGenerator

### DIFF
--- a/src/br/com/caelum/financas/modelo/Categoria.java
+++ b/src/br/com/caelum/financas/modelo/Categoria.java
@@ -1,0 +1,49 @@
+package br.com.caelum.financas.modelo;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
+
+@Table(name = "Categoria")
+@Entity
+public class Categoria {
+
+	@Id
+	@TableGenerator(table = "Categoria_PK", 
+			name = "categoria_generator",
+			pkColumnValue = "conta")
+	@GeneratedValue(strategy = GenerationType.TABLE,
+			generator = "categoria_generator")
+	private Long id;
+	
+	@Column(name = "nome")
+	private String nome;
+	
+	public Categoria(Long id, String nome) {
+		if (id != null) {
+			this.id = id;
+		}
+		this.nome = nome;
+	}
+
+	public String getNome() {
+		return nome;
+	}
+
+	public void setNome(String nome) {
+		this.nome = nome;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+	
+}

--- a/src/br/com/caelum/financas/modelo/Usuario.java
+++ b/src/br/com/caelum/financas/modelo/Usuario.java
@@ -1,0 +1,57 @@
+package br.com.caelum.financas.modelo;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+/*
+ No mapeamento abaixo estamos usando uma sequence que poderia ser usada para o Postgres ou Oracle.
+ O MySQL Não suporta Sequences, ou seja, teremos um erro no commit
+ */
+
+@Table(name = "Usuario")
+@Entity
+public class Usuario {
+
+	//Esta Sequence seria para Postgres e Oracle
+	@Id
+	@SequenceGenerator(name = "usuarioGenerator", 
+			initialValue = 1, 
+			allocationSize = 10,
+			sequenceName = "SEQ_USUARIO")
+	@GeneratedValue(
+			strategy = GenerationType.SEQUENCE,
+			generator = "usuarioGenerator")
+	private Long id;
+	
+	@Column(name = "nome", length = 50)
+	private String nome;
+	
+	public Usuario(Long id, String nome) {
+		if (id != null) {
+			this.id = id;
+		}
+		this.nome = nome;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getNome() {
+		return nome;
+	}
+
+	public void setNome(String nome) {
+		this.nome = nome;
+	}
+	
+}

--- a/src/br/com/caelum/financas/modelo/Usuario.java
+++ b/src/br/com/caelum/financas/modelo/Usuario.java
@@ -1,7 +1,6 @@
 package br.com.caelum.financas.modelo;
 
 import javax.persistence.Column;
-import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -14,7 +13,7 @@ import javax.persistence.Table;
  */
 
 @Table(name = "Usuario")
-@Entity
+//@Entity //esta comentado pois gera excecao
 public class Usuario {
 
 	//Esta Sequence seria para Postgres e Oracle

--- a/src/br/com/caelum/financas/modelo/crud/usuario/TestaInsereCategoria.java
+++ b/src/br/com/caelum/financas/modelo/crud/usuario/TestaInsereCategoria.java
@@ -1,0 +1,56 @@
+package br.com.caelum.financas.modelo.crud.usuario;
+
+import javax.persistence.EntityManager;
+
+import br.com.caelum.financas.infra.JPAUtil;
+import br.com.caelum.financas.modelo.Categoria;
+
+public class TestaInsereCategoria {
+
+	public static void main(String[] args) {
+		EntityManager manager = new JPAUtil().getEntityManager();
+		Categoria categoria = new Categoria(null, "Poupanca");
+		
+		manager.getTransaction().begin();
+		manager.persist(categoria);
+		manager.getTransaction().commit();
+		
+		manager.close();
+	}
+	
+}
+
+/*
+Primeira Execução:
+Hibernate: 
+    select
+        sequence_next_hi_value 
+    from
+        Categoria_PK 
+    where
+        sequence_name = 'conta' for update
+            
+Hibernate: Nao temos esse insert na segunda execução
+    insert 
+    into
+        Categoria_PK
+        (sequence_name, sequence_next_hi_value) 
+    values
+        ('conta', ?)
+Hibernate: 
+    update
+        Categoria_PK 
+    set
+        sequence_next_hi_value = ? 
+    where
+        sequence_next_hi_value = ? 
+        and sequence_name = 'conta'
+Hibernate: 
+    insert 
+    into
+        Categoria
+        (nome, id) 
+    values
+        (?, ?)
+
+ */

--- a/src/br/com/caelum/financas/modelo/crud/usuario/TestaInsereUsuario.java
+++ b/src/br/com/caelum/financas/modelo/crud/usuario/TestaInsereUsuario.java
@@ -1,0 +1,21 @@
+package br.com.caelum.financas.modelo.crud.usuario;
+
+import javax.persistence.EntityManager;
+
+import br.com.caelum.financas.infra.JPAUtil;
+import br.com.caelum.financas.modelo.Usuario;
+
+public class TestaInsereUsuario {
+
+	public static void main(String[] args) {
+		EntityManager manager = new JPAUtil().getEntityManager();
+		Usuario usuario = new Usuario(null, "Gama");
+		
+		manager.getTransaction().begin();
+		manager.persist(usuario);
+		manager.getTransaction().commit(); //Erro pois o MySQL não suporta Sequences
+		
+		manager.close();
+	}
+	
+}


### PR DESCRIPTION
- Utilizar o @TableGenerator
- Utilizar o GenerationType.TABLE
- Lembrar que o MySQL não suporta Sequences
- Lembrar que o padrão utilizado pelo JPA é o GenerationType.AUTO
- Lembrar que o MySQL utiliza GenerationType.IDENTITY por default
